### PR TITLE
Change settings to downgrade to JDK21 for better compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:23
+FROM openjdk:21
 LABEL authors="BBRZ-Java"
 
 COPY target/kaiser*.jar app.jar

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>23</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -62,6 +62,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<source>21</source>
+					<target>21</target>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,4 +15,3 @@ spring:
     console:
       path: /h2
       enabled: true
-      settings.web-allow-others: true


### PR DESCRIPTION
Additional steps that may be necessary for it to run in IntelliJ

1. Check IntelliJ’s JDK Version
  Go to File > Project Structure > Project and verify:
  
  Project SDK: Set this to JDK 21.
  Project Language Level: Set to 21 (Java 21).

2. Check IntelliJ's Compiler Settings
  Go to File > Settings > Build, Execution, Deployment > Compiler > Java Compiler:
  
  Under Target bytecode version, set it to 21.